### PR TITLE
pretty text for note content, wrap and hide overflow of meta

### DIFF
--- a/main.js
+++ b/main.js
@@ -60,9 +60,7 @@ function displayNotes(notes) {
     noteContent.classList.add(
       "note-content",
       "mb-10", // Margin bottom 10 units
-      "overflow-hidden", // Hide overflow text
-      "text-ellipsis", // Add ellipsis if text overflows
-      "break-all" // Break all words to prevent overflow
+      "text-pretty"
     );
     noteContent.textContent = note.content;
 
@@ -71,8 +69,11 @@ function displayNotes(notes) {
     noteMeta.classList.add(
       "note-meta",
       "text-sm", // Small font size
-      "text-gray-600" // Text color gray-600
+      "text-gray-600", // Text color gray-600
+      "text-wrap",
+      "overflow-hidden"
     );
+
     noteMeta.innerHTML = `
       <span>Published: ${new Date(
         note.created_at * 1000

--- a/style/output.css
+++ b/style/output.css
@@ -1829,6 +1829,16 @@ video {
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
 }
 
+.bg-gray-600 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(75 85 99 / var(--tw-bg-opacity));
+}
+
+.bg-slate-300 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(203 213 225 / var(--tw-bg-opacity));
+}
+
 .decoration-slice {
   -webkit-box-decoration-break: slice;
           box-decoration-break: slice;
@@ -2031,6 +2041,10 @@ video {
 
 .font-sans {
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+
+.font-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .text-2xl {


### PR DESCRIPTION
Note content split on characters instead of by word on resize. Fixed that. The meta id was overflowing on mobile, so I added text wrapping and hide overflow for note meta. Only downside to this is you can't copy the whole id if the client screen isn't big enough. 